### PR TITLE
chore: extend .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,44 @@
-node_modules
+**/.git
+**/.gitignore
+**/.gitattributes
+**/.dockerignore
+**/Dockerfile
+**/*.Dockerfile
+**/Dockerfile.*
+**/docker-compose.yml
+**/.editorconfig
+
+# Adapted from /.gitignore
+**/node_modules
 # Keep environment variables out of version control
-.env
+**/.env
 /prisma/dev.db
 /prisma/dev.db-journal
-/.vscode
+**/.vscode
 /dev.crt
 /dev.key
 /dataproxy/schema.prisma
 /generated
 .DS_Store
+
+# Adapted from /dataproxy/.gitignore
+**/.yarn/*
+!**/.yarn/patches
+!**/.yarn/plugins
+!**/.yarn/releases
+!**/.yarn/versions
+
+**/coverage
+**/coverage.json
+
+# misc
+**/.DS_Store
+
+# debug
+**/npm-debug.log*
+**/yarn-debug.log*
+**/yarn-error.log*
+**/.pnpm-debug.log*
+
+# typescript
+**/*.tsbuildinfo


### PR DESCRIPTION
To keep build context clean as possible.