### PR TITLE
Fix webhook test message format

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -128,8 +128,8 @@ export async function api(
       { routingKey: EvmEventsQueueName },
       { contentType: "application/octet-stream" },
       serializeEventMessage({
-        address,
-        sigHash: abiHash,
+        address: toBytes(address),
+        sigHash: toBytes(abiHash),
         topics: [],
         blockTimestamp: BigInt(Math.floor(Date.now() / 1000)),
         txIndex: -1n,


### PR DESCRIPTION
It seems like webhook test was broken since we changed the event message marshal format.