### PR TITLE
Github Actions workflow for docker images publish

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@
 **/Dockerfile.*
 **/docker-compose.yml
 **/.editorconfig
+**/.github
 
 # Adapted from /.gitignore
 **/node_modules

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,62 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: publish-docker
+permissions:
+  statuses: none
+on:
+  push:
+    branches:
+    - "main"
+    tags:
+      - "*"
+  pull_request: {}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@main
+    - run: git fetch --tags
+    - name: Get latest tag on current branch
+      id: branchtag
+      run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo '0.0.0')" >> "$GITHUB_OUTPUT"
+    - name: Get next minor version
+      id: semvers
+      uses: WyriHaximus/github-action-next-semvers@v1
+      with:
+        version: ${{ steps.branchtag.outputs.tag }}
+    - name: Generate docker image tag
+      id: docker-tag
+      run: ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags/') }} && echo "version=${{ steps.branchtag.outputs.tag }}"  >> "$GITHUB_OUTPUT" || echo "version=${{ steps.semvers.outputs.minor }}-dev.$(date -u +%Y%m%d%H%M%S)" >> "$GITHUB_OUTPUT"
+    - run: docker compose build
+      env:
+        VERSION: ${{ steps.docker-tag.outputs.version }}
+    - name: Export built docker images
+      run: docker save -o docker-images.tar $(docker images 'ghcr.io/planetarium/*' --format '{{.Repository}}:{{.Tag}}' | tr '\n' ' ')
+    - uses: actions/upload-artifact@main
+      with:
+        name: docker-images
+        path: docker-images.tar
+  publish:
+    permissions:
+      packages: write
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: ${{ github.event_name == 'push' }}
+    steps:
+    - uses: actions/checkout@main
+    - run: git fetch --tags
+    - name: Get latest tag on the repository
+      id: repotag
+      run: echo "tag=$(git for-each-ref --sort=-creatordate --count 1 --format='%(refname:short)' refs/tags)" >> "$GITHUB_OUTPUT"
+    - uses: actions/download-artifact@main
+      with:
+        name: docker-images
+    - run: docker load -i docker-images.tar
+    - name: Tag docker images if not upstream
+      if: ${{ github.repository_owner != 'planetarium' }}
+      run: for tag in $(docker images 'ghcr.io/planetarium/*' --format '{{.Repository}}:{{.Tag}}'); do docker tag "$tag" "ghcr.io/${{ github.repository_owner }}${tag#ghcr.io/planetarium}"; done
+    - name: Tag docker images if git tag is latest
+      if: ${{ contains(github.ref, 'refs/tags/') && github.ref_name == steps.repotag.outputs.tag }}
+      run: for tag in $(docker images 'ghcr.io/${{ github.repository_owner }}/*' --format '{{.Repository}}:{{.Tag}}'); do docker tag "$tag" "${tag%:*}:latest"; done
+    - run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+    - name: Push all images to ghcr
+      run: for tag in $(docker images 'ghcr.io/${{ github.repository_owner }}/*' --format '{{.Repository}}:{{.Tag}}'); do docker push "$tag"; done

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ FROM common as web-builder
 WORKDIR /Corvette/web
 ARG DENO_DEPLOYMENT_ID
 RUN apk add git && \
-  echo "DENO_DEPLOYMENT_ID=$(git rev-parse HEAD | cut -c -7)-$(date +%s)" > .env && \
+  echo "DENO_DEPLOYMENT_ID=$(git rev-parse HEAD | cut -c -7)-$(date -u +%Y%m%d%H%M%S)" > .env && \
   [ ! -z "$DENO_DEPLOYMENT_ID" ] && echo "DENO_DEPLOYMENT_ID=$DENO_DEPLOYMENT_ID" > .env ; \
   deno cache main.ts && \
   deno cache ../scripts/run-with-env.ts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     depends_on:
       message-queue-broker:
         condition: service_healthy
-    image: "planetarium/corvette-observer:${VERSION:-build-latest}"
+    image: "ghcr.io/planetarium/corvette-observer:${VERSION:-build-latest}"
     build:
       context: .
       target: observer
@@ -17,7 +17,7 @@ services:
     depends_on:
       message-queue-broker:
         condition: service_healthy
-    image: "planetarium/corvette-emitter:${VERSION:-build-latest}"
+    image: "ghcr.io/planetarium/corvette-emitter:${VERSION:-build-latest}"
     build:
       context: .
       target: emitter
@@ -31,7 +31,7 @@ services:
     depends_on:
       message-queue-broker:
         condition: service_healthy
-    image: "planetarium/corvette-api:${VERSION:-build-latest}"
+    image: "ghcr.io/planetarium/corvette-api:${VERSION:-build-latest}"
     ports:
       - "8000:8000/tcp"
     build:
@@ -48,7 +48,7 @@ services:
         condition: service_healthy
       api:
         condition: service_started
-    image: "planetarium/corvette-web:${VERSION:-build-latest}"
+    image: "ghcr.io/planetarium/corvette-web:${VERSION:-build-latest}"
     ports:
       - "3000:3000/tcp"
     environment:


### PR DESCRIPTION
Resolves #23.
Build docker images and publish to [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for easy deployment.
Automatic versioning depending on the branch's latest tag and push 'latest' tag on the most recent release tag.
Example of published images:
  - https://github.com/tkiapril/Corvette/pkgs/container/corvette-observer
  - https://github.com/tkiapril/Corvette/pkgs/container/corvette-api
  - https://github.com/tkiapril/Corvette/pkgs/container/corvette-web
  - https://github.com/tkiapril/Corvette/pkgs/container/corvette-emitter