### PR TITLE
Use single watch for all sources

### DIFF
--- a/observer.ts
+++ b/observer.ts
@@ -6,6 +6,7 @@ import {
   Chain,
   createPublicClient,
   http as httpViemTransport,
+  Log,
   toBytes,
   toHex,
 } from "npm:viem";
@@ -48,15 +49,15 @@ export async function observer(
     routingKey: ControlObserverRoutingKey,
   });
   await amqpChannel.declareQueue({ queue: EvmEventsQueueName });
-  let unwatchEvents = await createWatch();
+  let unwatch = await createWatch();
   await amqpChannel.consume(
     { queue: controlQueue.queue },
     async (_args, _props, data) => {
       if (
         deserializeControlMessage(data).action === ReloadControlMessage.action
       ) {
-        unwatchEvents.forEach((unwatch) => unwatch());
-        unwatchEvents = await createWatch();
+        unwatch();
+        unwatch = await createWatch();
       }
     },
   );
@@ -66,7 +67,7 @@ export async function observer(
 
   async function cleanup() {
     abortController.abort();
-    unwatchEvents.forEach((unwatch) => unwatch());
+    unwatch();
     await runningPromise;
   }
 
@@ -74,64 +75,89 @@ export async function observer(
 
   // TODO: customizable poll interval and transport
   async function createWatch() {
-    return (await prisma.eventSource.findMany({
+    const sources = (await prisma.eventSource.findMany({
       select: { abiHash: true, address: true, Abi: { select: { json: true } } },
-    })).map((item) => {
-      const event = JSON.parse(item.Abi.json) as AbiEvent;
-      return client.watchEvent({
-        address: toHex(item.address as unknown as Uint8Array),
-        event,
-        onLogs: async (logs) => {
-          for (const log of logs) {
-            if (log.blockNumber == null) throw new Error("blockNumber is null");
-            if (log.transactionIndex == null) {
-              throw new Error("txIndex is null");
-            }
-            if (log.logIndex == null) throw new Error("logIndex is null");
-            if (log.blockHash == null) throw new Error("blockHash is null");
-            if (log.transactionHash == null) throw new Error("txHash is null");
-
-            const timestamp =
-              (await client.getBlock({ blockHash: log.blockHash! })).timestamp;
-            const blockHashBytes = toBytes(log.blockHash);
-            const addressBytes = toBytes(log.address);
-            const topicsBytes = log.topics.map(toBytes).map(Buffer.from);
-
-            await prisma.event.create({
-              data: {
-                blockTimestamp: new Date(Number(timestamp) * 1000),
-                txIndex: log.transactionIndex,
-                logIndex: log.logIndex,
-                blockNumber: Number(log.blockNumber),
-                blockHash: Buffer.from(blockHashBytes),
-                txHash: Buffer.from(toBytes(log.transactionHash)),
-                sourceAddress: Buffer.from(addressBytes),
-                abiHash: item.abiHash,
-                topic1: topicsBytes[1],
-                topic2: topicsBytes[2],
-                topic3: topicsBytes[3],
-                data: Buffer.from(toBytes(log.data)),
-              },
-            });
-
-            amqpChannel.publish(
-              { routingKey: EvmEventsQueueName },
-              { contentType: "application/octet-stream" },
-              serializeEventMessage({
-                address: addressBytes,
-                sigHash: item.abiHash as unknown as Uint8Array,
-                topics: topicsBytes,
-                blockTimestamp: timestamp,
-                txIndex: BigInt(log.transactionIndex),
-                logIndex: BigInt(log.logIndex),
-                blockNumber: log.blockNumber,
-                blockHash: blockHashBytes,
-              }),
-            );
-          }
-        },
-      });
+    })).reduce((acc, item) => {
+      const address = toHex(item.address as unknown as Uint8Array);
+      const entry = toHex(item.abiHash);
+      if (acc[address] === undefined) acc = { ...acc, [address]: [entry] };
+      else acc[address].push(entry);
+      return acc;
+    }, {} as Record<string, string[]>);
+    return client.watchEvent({
+      address: Object.keys(sources) as `0x${string}`[],
+      onLogs: (logs) =>
+        Promise.all(
+          logs.map((log) => {
+            if (
+              sources[log.address] !== undefined &&
+              log.topics[0] !== undefined &&
+              sources[log.address].includes(log.topics[0])
+            ) return processLog(log);
+            return undefined;
+          }).filter((onLog) => onLog !== undefined) as Promise<
+            void
+          >[] satisfies Promise<void>[],
+        ),
     });
+  }
+
+  async function processLog(
+    log: Log<
+      bigint,
+      number,
+      AbiEvent | undefined,
+      undefined,
+      [AbiEvent | undefined],
+      string
+    >,
+  ) {
+    if (log.blockNumber == null) throw new Error("blockNumber is null");
+    if (log.transactionIndex == null) {
+      throw new Error("txIndex is null");
+    }
+    if (log.logIndex == null) throw new Error("logIndex is null");
+    if (log.blockHash == null) throw new Error("blockHash is null");
+    if (log.transactionHash == null) throw new Error("txHash is null");
+
+    const timestamp =
+      (await client.getBlock({ blockHash: log.blockHash! })).timestamp;
+    const blockHashBytes = toBytes(log.blockHash);
+    const addressBytes = toBytes(log.address);
+    const topicsBytes = log.topics.map(toBytes).map(Buffer.from);
+    const [abiHash, topic1, topic2, topic3] = topicsBytes;
+
+    await prisma.event.create({
+      data: {
+        blockTimestamp: new Date(Number(timestamp) * 1000),
+        txIndex: log.transactionIndex,
+        logIndex: log.logIndex,
+        blockNumber: Number(log.blockNumber),
+        blockHash: Buffer.from(blockHashBytes),
+        txHash: Buffer.from(toBytes(log.transactionHash)),
+        sourceAddress: Buffer.from(addressBytes),
+        abiHash,
+        topic1,
+        topic2,
+        topic3,
+        data: Buffer.from(toBytes(log.data)),
+      },
+    });
+
+    amqpChannel.publish(
+      { routingKey: EvmEventsQueueName },
+      { contentType: "application/octet-stream" },
+      serializeEventMessage({
+        address: addressBytes,
+        sigHash: abiHash,
+        topics: topicsBytes,
+        blockTimestamp: timestamp,
+        txIndex: BigInt(log.transactionIndex),
+        logIndex: BigInt(log.logIndex),
+        blockNumber: log.blockNumber,
+        blockHash: blockHashBytes,
+      }),
+    );
   }
 }
 


### PR DESCRIPTION
Apparently eth_newFilter supports watching multiple addresses at once, so we utilize it.