### PR TITLE
Fix argon2 wasm load bug with shim

### DIFF
--- a/web/routes/api/join.ts
+++ b/web/routes/api/join.ts
@@ -1,10 +1,8 @@
 import { Handlers, Status } from "fresh/server.ts";
 import type { WithSession } from "fresh-session";
 
-import argon2 from "https://esm.sh/argon2-browser@1.18.0/dist/argon2-bundled.min.js";
-
 import { prisma } from "~/main.ts";
-import { redirect } from "~/util.ts";
+import { argon2, redirect } from "~/util.ts";
 
 export const handler: Handlers<unknown, WithSession> = {
   async POST(req, ctx) {

--- a/web/routes/api/login.ts
+++ b/web/routes/api/login.ts
@@ -2,10 +2,8 @@ import { Handlers, Status } from "fresh/server.ts";
 import type { WithSession } from "fresh-session";
 import { decode } from "std/encoding/base64.ts";
 
-import argon2 from "https://esm.sh/argon2-browser@1.18.0/dist/argon2-bundled.min.js";
-
 import { prisma } from "~/main.ts";
-import { redirect } from "~/util.ts";
+import { argon2, redirect } from "~/util.ts";
 
 export const handler: Handlers<unknown, WithSession> = {
   async POST(req, ctx) {

--- a/web/util.ts
+++ b/web/util.ts
@@ -29,3 +29,32 @@ export const checkPermission = async (
   if (entries.find((e) => e.userId === user.id)) return true;
   return false;
 };
+
+const globalThisShim = globalThis as {
+  process?: { versions?: { node?: unknown } };
+};
+const needPatch = globalThisShim.process !== undefined &&
+  globalThisShim.process.versions !== undefined &&
+  globalThisShim.process.versions.node !== undefined;
+if (needPatch) {
+  Object.assign(globalThis, {
+    process: {
+      ...globalThisShim.process,
+      versions: { ...globalThisShim.process!.versions, node: undefined },
+    },
+  });
+}
+import _argon2 from "https://esm.sh/argon2-browser@1.18.0/dist/argon2-bundled.min.js";
+export import argon2 = _argon2;
+await argon2.hash({ pass: new Uint8Array(0), salt: new Uint8Array(8) });
+if (needPatch) {
+  Object.assign(globalThis, {
+    process: {
+      ...globalThisShim.process,
+      versions: {
+        ...globalThisShim.process!.versions,
+        node: globalThisShim.process!.versions!.node,
+      },
+    },
+  });
+}


### PR DESCRIPTION
The argon2 library we use, node:argon2-browser, sees if globalThis.process.versions.node exists, and if it is there, it assumes the runtime is nodejs and try to use local require. We inject node.process into globalThis for prisma shimming, so argon2-browser incorrectly identifies the runtime as node, resulting in import error. This shim tries to fix that by temporarily removing the field.