### PR TITLE
Enable multiple observer

### DIFF
--- a/prisma-shim.ts
+++ b/prisma-shim.ts
@@ -2,17 +2,13 @@ import { createRequire } from "node:module";
 import process from "node:process";
 import { Buffer } from "node:buffer";
 
-import * as _prisma from "./generated/client/index.js";
 import * as _prismaTypes from "./generated/client/index.d.ts";
-
-type PrismaTypes = typeof _prismaTypes;
 
 Object.assign(globalThis, { process, Buffer });
 
 const require = createRequire(import.meta.url);
-const prisma: PrismaTypes = require("./generated/client");
+const prisma: typeof _prismaTypes = require("./generated/client");
 
 export class PrismaClient extends prisma.PrismaClient {}
-// re-export namespace Prisma
-// deno-lint-ignore no-unused-vars
-export import Prisma = _prismaTypes.Prisma;
+// re-export namespace Prisma as default export
+export default prisma.Prisma;

--- a/runHelpers.ts
+++ b/runHelpers.ts
@@ -10,7 +10,8 @@ import { parseOptions } from "https://deno.land/x/amqp@v0.23.1/src/amqp_connect_
 
 import { Chain } from "npm:viem";
 
-import { type Prisma, PrismaClient } from "./prisma-shim.ts";
+import type Prisma from "./prisma-shim.ts";
+import { PrismaClient } from "./prisma-shim.ts";
 
 import {
   AmqpBrokerUrlEnvKey,

--- a/web/util.ts
+++ b/web/util.ts
@@ -2,7 +2,7 @@ import { getCookies } from "std/http/cookie.ts";
 import { join, resolve } from "std/path/mod.ts";
 
 import { listenUrl, prisma } from "~/main.ts";
-import type { Prisma } from "~root/prisma-shim.ts";
+import type Prisma from "~root/prisma-shim.ts";
 import type { User } from "~root/generated/client/index.d.ts";
 
 export const getOrigin = (req: Request) => new URL(req.url).origin;


### PR DESCRIPTION
Now, observer ignores unique constraint failure on event insert, and It is now able to use multiple observers simultanously.
Also, prisma-shim now exports Prisma namespace as default export, which enables Prisma to be referenced both as type and value.