### PR TITLE
web: pass LogLevel to logRequest instead of method, fixed log in web

### DIFF
--- a/web/routes/_404.tsx
+++ b/web/routes/_404.tsx
@@ -1,8 +1,10 @@
+import { LogLevels } from "std/log/levels.ts";
+
 import { Handler, Status } from "fresh/server.ts";
+
 import { logRequest, redirect } from "~/util.ts";
-import { logger } from "~root/web/main.ts";
 
 export const handler: Handler = (req, ctx) => {
-  logRequest(logger.warning, req, ctx, Status.NotFound, "Redirecting to default route")
+  logRequest(LogLevels.WARNING, req, ctx, Status.NotFound, "Redirecting to default route")
   return redirect(req, ctx);
 };

--- a/web/routes/_middleware.ts
+++ b/web/routes/_middleware.ts
@@ -1,8 +1,9 @@
+import { LogLevels } from "std/log/levels.ts";
+
 import { cookieSession, WithSession } from "fresh-session";
 import { MiddlewareHandlerContext, Status } from "fresh/server.ts";
 
 import { User } from "~root/generated/client/index.d.ts";
-import { logger } from "~root/web/main.ts";
 
 import { logRequest, redirect } from "~/util.ts";
 
@@ -26,8 +27,8 @@ const redirectionHandler = (
     ctx.state.session.set("user", undefined);
     ctx.state.session.destroy();
     if (email) {
-      logRequest(logger.info, req, ctx, Status.OK, `User ${email} logged out`);
-    } else logRequest(logger.info, req, ctx, Status.NotModified);
+      logRequest(LogLevels.INFO, req, ctx, Status.OK, `User ${email} logged out`);
+    } else logRequest(LogLevels.INFO, req, ctx, Status.NotModified);
     return redirect(req, ctx, "/login");
   }
 
@@ -42,7 +43,7 @@ const redirectionHandler = (
     return ctx.next();
   }
 
-  logRequest(logger.warning, req, ctx, Status.Unauthorized);
+  logRequest(LogLevels.WARNING, req, ctx, Status.Unauthorized);
   return redirect(req, ctx, "/login");
 };
 

--- a/web/routes/abi.tsx
+++ b/web/routes/abi.tsx
@@ -1,8 +1,10 @@
+import { LogLevels } from "std/log/levels.ts";
+
 import { Handlers, PageProps, Status } from "fresh/server.ts";
+
 import { Layout } from "~/components/Layout.tsx";
 import { type AbiEntry, ListAbi } from "~/islands/ListAbi.tsx";
 import { logRequest, getCookieString, getServerSideUrl } from "~/util.ts";
-import { logger } from "~root/web/main.ts";
 
 export const handler: Handlers<AbiEntry[]> = {
   async GET(req, ctx) {
@@ -11,10 +13,10 @@ export const handler: Handlers<AbiEntry[]> = {
       headers: { cookie: getCookieString(req) },
     });
     if (!res.ok) {
-      logRequest(logger.error, req, ctx, Status.InternalServerError, "Failed to retrieve abi entries")
+      logRequest(LogLevels.ERROR, req, ctx, Status.InternalServerError, "Failed to retrieve abi entries")
       throw new Error(await res.text());
     }
-    logRequest(logger.info, req, ctx, Status.OK)
+    logRequest(LogLevels.INFO, req, ctx, Status.OK)
     return ctx.render(await res.json());
   },
 };

--- a/web/routes/api/abi.ts
+++ b/web/routes/api/abi.ts
@@ -1,3 +1,5 @@
+import { LogLevels } from "std/log/levels.ts";
+
 import { type Handlers, Status } from "fresh/server.ts";
 import type { WithSession } from "fresh-session";
 
@@ -8,7 +10,7 @@ import type { Abi, AbiEvent } from "https://esm.sh/abitype@0.9.0";
 
 import { formatAbiItemPrototype } from "~root/abitype.ts";
 import type { User } from "~root/generated/client/index.d.ts";
-import { logger, prisma } from "~/main.ts";
+import { prisma } from "~/main.ts";
 import { checkPermission, logRequest } from "~/util.ts";
 import type { AbiEntry } from "~/islands/ListAbi.tsx";
 
@@ -23,7 +25,7 @@ export const handler: Handlers<AbiEntry, WithSession> = {
       };
     });
     const body = JSON.stringify(entries);
-    logRequest(logger.debug, req, ctx, Status.OK, `Get abi entries: ${body}`);
+    logRequest(LogLevels.DEBUG, req, ctx, Status.OK, `Get abi entries: ${body}`);
     return new Response(body);
   },
 
@@ -69,7 +71,7 @@ export const handler: Handlers<AbiEntry, WithSession> = {
     ) => (res.status === "fulfilled" ? [res.value] : []));
     if (fulfilled.length === 0) {
       logRequest(
-        logger.debug,
+        LogLevels.DEBUG,
         req,
         ctx,
         Status.Forbidden,
@@ -80,7 +82,7 @@ export const handler: Handlers<AbiEntry, WithSession> = {
 
     const body = JSON.stringify(fulfilled);
     logRequest(
-      logger.info,
+      LogLevels.INFO,
       req,
       ctx,
       Status.OK,
@@ -96,7 +98,7 @@ export const handler: Handlers<AbiEntry, WithSession> = {
 
     if (!(await checkPermission({ type: "EventAbi", abiHash: hash }, user))) {
       logRequest(
-        logger.warning,
+        LogLevels.WARNING,
         req,
         ctx,
         Status.Forbidden,
@@ -106,7 +108,7 @@ export const handler: Handlers<AbiEntry, WithSession> = {
     }
 
     logRequest(
-      logger.warning,
+      LogLevels.WARNING,
       req,
       ctx,
       Status.OK,

--- a/web/routes/api/join.ts
+++ b/web/routes/api/join.ts
@@ -1,7 +1,9 @@
+import { LogLevels } from "std/log/levels.ts";
+
 import { Handlers, Status } from "fresh/server.ts";
 import type { WithSession } from "fresh-session";
 
-import { logger, prisma } from "~/main.ts";
+import { prisma } from "~/main.ts";
 import { logRequest, redirect } from "~/util.ts";
 import { hash } from "~/argon2.ts";
 
@@ -13,11 +15,11 @@ export const handler: Handlers<unknown, WithSession> = {
 
     if (!email || !password) {
       const message = "Empty email/password";
-      logRequest(logger.debug, req, ctx, Status.BadRequest, message);
+      logRequest(LogLevels.DEBUG, req, ctx, Status.BadRequest, message);
       return new Response(message, { status: Status.BadRequest });
     }
 
-    logRequest(logger.info, req, ctx, Status.OK, `Creating user: ${email}`);
+    logRequest(LogLevels.INFO, req, ctx, Status.OK, `Creating user: ${email}`);
     const user = await prisma.user.create({
       data: {
         email,

--- a/web/routes/api/login.ts
+++ b/web/routes/api/login.ts
@@ -1,7 +1,9 @@
+import { LogLevels } from "std/log/levels.ts";
+
 import { Handlers, Status } from "fresh/server.ts";
 import type { WithSession } from "fresh-session";
 
-import { logger, prisma } from "~/main.ts";
+import {  prisma } from "~/main.ts";
 import { logRequest, redirect } from "~/util.ts";
 import { verify } from "~/argon2.ts";
 
@@ -13,14 +15,14 @@ export const handler: Handlers<unknown, WithSession> = {
 
     if (!email || !password) {
       const message = "Empty email/password";
-      logRequest(logger.debug, req, ctx, Status.BadRequest, message);
+      logRequest(LogLevels.DEBUG, req, ctx, Status.BadRequest, message);
       return new Response(message, { status: Status.BadRequest });
     }
 
     const user = await prisma.user.findUnique({ where: { email } });
     if (!user || (await verify(password, user.password))) {
       logRequest(
-        logger.warning,
+        LogLevels.WARNING,
         req,
         ctx,
         Status.OK,
@@ -33,7 +35,7 @@ export const handler: Handlers<unknown, WithSession> = {
       });
     }
 
-    logRequest(logger.info, req, ctx, Status.OK, `Logging in user: ${email}`);
+    logRequest(LogLevels.INFO, req, ctx, Status.OK, `Logging in user: ${email}`);
     ctx.state.session.set("user", user);
 
     return redirect(req, ctx);

--- a/web/routes/api/sources.ts
+++ b/web/routes/api/sources.ts
@@ -1,3 +1,5 @@
+import { LogLevels } from "std/log/levels.ts";
+
 import { type Handlers, Status } from "fresh/server.ts";
 import type { WithSession } from "fresh-session";
 
@@ -8,7 +10,7 @@ import { formatAbiItemPrototype } from "~root/abitype.ts";
 import { reload as reloadControl } from "~root/control.ts";
 import { ControlObserverRoutingKey } from "~root/constants.ts";
 import type { User } from "~root/generated/client/index.d.ts";
-import { amqpChannel, logger, prisma } from "~/main.ts";
+import { amqpChannel, prisma } from "~/main.ts";
 import { checkPermission, logRequest } from "~/util.ts";
 import type { SourceEntry } from "~/islands/ListSources.tsx";
 
@@ -26,7 +28,7 @@ export const handler: Handlers<SourceEntry, WithSession> = {
 
     const body = JSON.stringify(entries);
     logRequest(
-      logger.debug,
+      LogLevels.DEBUG,
       req,
       ctx,
       Status.OK,
@@ -40,7 +42,7 @@ export const handler: Handlers<SourceEntry, WithSession> = {
     const { address, abiHash } = await req.json();
 
     logRequest(
-      logger.info,
+      LogLevels.INFO,
       req,
       ctx,
       Status.OK,
@@ -88,7 +90,7 @@ export const handler: Handlers<SourceEntry, WithSession> = {
       ))
     ) {
       logRequest(
-        logger.warning,
+        LogLevels.WARNING,
         req,
         ctx,
         Status.Forbidden,
@@ -98,7 +100,7 @@ export const handler: Handlers<SourceEntry, WithSession> = {
     }
 
     logRequest(
-      logger.warning,
+      LogLevels.WARNING,
       req,
       ctx,
       Status.OK,

--- a/web/routes/api/sources/testWebhook.ts
+++ b/web/routes/api/sources/testWebhook.ts
@@ -1,8 +1,10 @@
+import { LogLevels } from "std/log/levels.ts";
+
 import { Handlers, Status } from "fresh/server.ts";
 
 import { toBytes } from "npm:viem";
 
-import { amqpChannel, logger } from "~/main.ts";
+import { amqpChannel } from "~/main.ts";
 import { serializeEventMessage } from "~root/EventMessage.ts";
 import { EvmEventsQueueName } from "~root/constants.ts";
 import { logRequest } from "~root/web/util.ts";
@@ -12,7 +14,7 @@ export const handler: Handlers = {
     const { address, abiHash } = await req.json();
 
     logRequest(
-      logger.info,
+      LogLevels.INFO,
       req,
       ctx,
       Status.Accepted,

--- a/web/routes/api/webhook.ts
+++ b/web/routes/api/webhook.ts
@@ -1,3 +1,5 @@
+import { LogLevels } from "std/log/mod.ts";
+
 import { type Handlers, Status } from "fresh/server.ts";
 import type { WithSession } from "fresh-session";
 
@@ -7,7 +9,7 @@ import { getAddress, toBytes, toHex } from "npm:viem";
 import { reload as reloadControl } from "~root/control.ts";
 import { ControlEmitterRoutingKey } from "~root/constants.ts";
 import type { User } from "~root/generated/client/index.d.ts";
-import { amqpChannel, logger, prisma } from "~/main.ts";
+import { amqpChannel, prisma } from "~/main.ts";
 import { checkPermission, logRequest } from "~/util.ts";
 import type { WebhookEntry } from "~/islands/ListWebhook.tsx";
 
@@ -23,7 +25,7 @@ export const handler: Handlers<WebhookEntry, WithSession> = {
       topic3: item.topic3 ? toHex(item.topic3) : undefined,
     }));
     const body = JSON.stringify(entries);
-    logRequest(logger.debug, req, ctx, 200, `Get webhook entries: ${body}`);
+    logRequest(LogLevels.DEBUG, req, ctx, 200, `Get webhook entries: ${body}`);
     return new Response(body);
   },
   async POST(req, ctx) {
@@ -39,7 +41,7 @@ export const handler: Handlers<WebhookEntry, WithSession> = {
     );
 
     logRequest(
-      logger.info,
+      LogLevels.INFO,
       req,
       ctx,
       Status.OK,
@@ -90,7 +92,7 @@ export const handler: Handlers<WebhookEntry, WithSession> = {
       ))
     ) {
       logRequest(
-        logger.warning,
+        LogLevels.WARNING,
         req,
         ctx,
         Status.Forbidden,
@@ -100,7 +102,7 @@ export const handler: Handlers<WebhookEntry, WithSession> = {
     }
 
     logRequest(
-      logger.warning,
+      LogLevels.WARNING,
       req,
       ctx,
       Status.OK,

--- a/web/routes/sources.tsx
+++ b/web/routes/sources.tsx
@@ -1,8 +1,10 @@
+import { LogLevels } from "std/log/levels.ts";
+
 import { Handlers, PageProps, Status } from "fresh/server.ts";
+
 import { Layout } from "~/components/Layout.tsx";
 import { ListSources, type SourceEntry } from "~/islands/ListSources.tsx";
 import { getCookieString, getServerSideUrl, logRequest } from "~/util.ts";
-import { logger } from "~root/web/main.ts";
 
 export const handler: Handlers<SourceEntry[]> = {
   async GET(req, ctx) {
@@ -11,10 +13,10 @@ export const handler: Handlers<SourceEntry[]> = {
       headers: { cookie: getCookieString(req) },
     });
     if (!res.ok) {
-      logRequest(logger.error, req, ctx, Status.InternalServerError, "Failed to retrieve source entries")
+      logRequest(LogLevels.ERROR, req, ctx, Status.InternalServerError, "Failed to retrieve source entries")
       throw new Error(await res.text());
     }
-    logRequest(logger.info, req, ctx, Status.OK)
+    logRequest(LogLevels.INFO, req, ctx, Status.OK)
     return ctx.render(await res.json());
   },
 };

--- a/web/routes/webhook.tsx
+++ b/web/routes/webhook.tsx
@@ -1,8 +1,10 @@
+import { LogLevels } from "std/log/levels.ts";
+
 import { Handlers, PageProps, Status } from "fresh/server.ts";
+
 import { Layout } from "~/components/Layout.tsx";
 import { ListWebhook, type WebhookEntry } from "~/islands/ListWebhook.tsx";
 import { getCookieString, getServerSideUrl, logRequest } from "~/util.ts";
-import { logger } from "~root/web/main.ts";
 
 export const handler: Handlers<WebhookEntry[]> = {
   async GET(req, ctx) {
@@ -11,10 +13,10 @@ export const handler: Handlers<WebhookEntry[]> = {
       headers: { cookie: getCookieString(req) },
     });
     if (!res.ok) {
-      logRequest(logger.error, req, ctx, Status.InternalServerError, "Failed to retrieve webhook entries")
+      logRequest(LogLevels.ERROR, req, ctx, Status.InternalServerError, "Failed to retrieve webhook entries")
       throw new Error(await res.text());
     }
-    logRequest(logger.info, req, ctx, Status.OK)
+    logRequest(LogLevels.INFO, req, ctx, Status.OK)
     return ctx.render(await res.json());
   },
 };

--- a/web/util.ts
+++ b/web/util.ts
@@ -1,7 +1,9 @@
 import { getCookies } from "std/http/cookie.ts";
 import { join, resolve } from "std/path/mod.ts";
+import { LogLevels } from "std/log/mod.ts";
 
 import { ServeHandlerInfo, Status } from "fresh/server.ts";
+
 import { listenUrl, logger, prisma } from "~/main.ts";
 import type Prisma from "~root/prisma-shim.ts";
 import type { User } from "~root/generated/client/index.d.ts";
@@ -14,7 +16,7 @@ export const redirect = (req: Request, ctx: ServeHandlerInfo, url?: string) => {
   const origin = getOrigin(req);
   if (!url) url = `${origin}/abi`;
   if (!url.startsWith(origin)) url = resolve(origin, url);
-  logRequest(logger.debug, req, ctx, 302, `Redirect -> ${url}`);
+  logRequest(LogLevels.DEBUG, req, ctx, 302, `Redirect -> ${url}`);
   return new Response(null, { status: 302, headers: { location: url } });
 };
 
@@ -35,20 +37,47 @@ export const checkPermission = async (
 };
 
 export const logRequest = (
-  loggingMethod: (msgFunc: () => unknown) => unknown,
+  logLevel: LogLevels,
   req: Request,
   ctx: ServeHandlerInfo,
   status: Status,
   message?: string,
 ) => {
-  const clonedReq = req.clone();
-  clonedReq.text().then((reqText) => {
-    loggingMethod(() =>
-      `${status} ${
-        new URL(clonedReq.url).pathname
-      } ${clonedReq.method} ${ctx.remoteAddr.hostname} ${reqText}${
+  function bodyCallback(reqText?: string) {
+    function log() {
+      const requestDetails = `${reqText ?? ""}${
         message !== undefined ? `: ${message}` : ""
-      }.`
-    );
-  });
+      }`;
+      return `${status} ${
+        new URL(req.url).pathname
+      } ${req.method} ${ctx.remoteAddr.hostname}${
+        requestDetails != "" ? ` ${requestDetails}` : ""
+      }.`;
+    }
+    switch (logLevel) {
+      case LogLevels.NOTSET:
+      case LogLevels.DEBUG:
+        logger.debug(log);
+        break;
+      case LogLevels.INFO:
+        logger.info(log);
+        break;
+      case LogLevels.WARNING:
+        logger.warning(log);
+        break;
+      case LogLevels.ERROR:
+        logger.error(log);
+        break;
+      case LogLevels.CRITICAL:
+        logger.critical(log);
+        break;
+    }
+  }
+
+  try {
+    const clonedReq = req.clone();
+    clonedReq.text().then(bodyCallback);
+  } catch {
+    bodyCallback();
+  }
 };


### PR DESCRIPTION
Apparently passing logging method to logRequest doesn't work well, so we now pass LogLevel.