### PR TITLE
🚀 Release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 _First release._
 
-[0.1.0]: https://github.com/planetarium/Corvette/releases/tag/0.0.0
+[0.1.0]: https://github.com/planetarium/Corvette/releases/tag/0.1.0


### PR DESCRIPTION
The former release PR (#65) had an typo in the link, so it is corrected.